### PR TITLE
refactor: remove unused dependency providers

### DIFF
--- a/backend/app/infrastructure/cache/cache_service.py
+++ b/backend/app/infrastructure/cache/cache_service.py
@@ -114,8 +114,3 @@ class CacheRedisService(RedisBase):
 # 全局实例和依赖提供函数
 cache_redis_service = CacheRedisService()
 
-
-def get_cache_redis_service() -> CacheRedisService:
-    """FastAPI 依赖项：获取缓存相关的 Redis 服务"""
-    return cache_redis_service
-

--- a/backend/app/infrastructure/scheduler/scheduler.py
+++ b/backend/app/infrastructure/scheduler/scheduler.py
@@ -171,7 +171,3 @@ class SchedulerService:
 # 全局实例
 scheduler_service = SchedulerService()
 
-
-def get_scheduler_service() -> SchedulerService:
-    """FastAPI 依赖项：获取调度器服务"""
-    return scheduler_service


### PR DESCRIPTION
## Summary
- remove unused SchedulerService dependency provider
- remove unused CacheRedisService dependency provider

## Testing
- ⚠️ `pytest` (fails: ModuleNotFoundError: No module named 'app')


------
https://chatgpt.com/codex/tasks/task_e_68b928b5654c83249a7ed309504ee342