### PR TITLE
Ensure Taskiq context for execution logging

### DIFF
--- a/backend/app/infrastructure/tasks/exec_record_decorators.py
+++ b/backend/app/infrastructure/tasks/exec_record_decorators.py
@@ -4,8 +4,10 @@
 import asyncio
 import functools
 import logging
-from typing import Callable, Any, Optional, Dict
 from datetime import datetime
+from typing import Any, Callable, Dict, Optional
+
+from taskiq import Context, TaskiqDepends
 
 logger = logging.getLogger(__name__)
 
@@ -18,13 +20,13 @@ async def _create_execution_record(
     completed_at: datetime,
     duration_seconds: Optional[float] = None,
     result: Optional[Dict[str, Any]] = None,
-    error_message: Optional[str] = None
-):
-    """创建任务执行记录（原executor功能）"""
+    error_message: Optional[str] = None,
+) -> None:
+    """创建任务执行记录（原 executor 功能）"""
     try:
         from app.infrastructure.database.postgres_base import AsyncSessionLocal
         from app.modules.tasks.repository import crud_task_execution
-        
+
         async with AsyncSessionLocal() as db:
             await crud_task_execution.create(
                 db=db,
@@ -35,64 +37,51 @@ async def _create_execution_record(
                 completed_at=completed_at,
                 duration_seconds=duration_seconds,
                 result=result,
-                error_message=error_message
+                error_message=error_message,
             )
-            logger.debug(f"已创建执行记录: task_id={task_id}, success={is_success}")
-    except Exception as e:
-        logger.error(f"创建执行记录失败: {e}")
+            logger.debug(
+                f"已创建执行记录: task_id={task_id}, success={is_success}"
+            )
+    except Exception:
+        logger.exception("创建执行记录失败")
+        raise
 
 
 def execution_handler(func: Callable) -> Callable:
     """
-    改进的超时处理装饰器 - 使用新的is_success记录方式
-    
+    改进的超时处理装饰器 - 使用新的 is_success 记录方式
+
     Args:
         func: 要装饰的任务函数
-        
+
     Returns:
         装饰后的函数
     """
-    
+
     @functools.wraps(func)
-    async def wrapper(*args, **kwargs) -> Any:
-        # 提取config_id参数
-        config_id = kwargs.get('config_id')
+    async def wrapper(
+        *args,
+        context: Context = TaskiqDepends(),
+        **kwargs,
+    ) -> Any:
+        # 提取 config_id 参数
+        config_id = kwargs.get("config_id")
         if config_id is None and args:
-            # 通常config_id是第一个参数
+            # 通常 config_id 是第一个参数
             config_id = args[0] if isinstance(args[0], (int, type(None))) else None
-        
-        # 智能地查找 Context 对象
-        from taskiq import Context
-        context: Context = None
-        
-        # 从 args 中查找 Context 实例
-        for arg in args:
-            if isinstance(arg, Context):
-                context = arg
-                break
-        
-        # 如果 args 中没有，从 kwargs 中查找
-        if not context:
-            for kwarg_val in kwargs.values():
-                if isinstance(kwarg_val, Context):
-                    context = kwarg_val
-                    break
-        
-        # 从 Context 中安全地获取 task_id
+
         real_task_id = None
-        if context and hasattr(context, 'message') and context.message:
+        if context and getattr(context, "message", None):
             real_task_id = context.message.task_id
-        
-        # 如果上下文中没有，再从 kwargs 中找备选
-        if not real_task_id:
-            real_task_id = kwargs.get('task_id')
-        
+
         start_time = datetime.utcnow()
-        
+
         try:
-            logger.debug(f"开始执行任务 {func.__name__} (config_id={config_id}, task_id={real_task_id})")
-            result = await func(*args, **kwargs)
-            
+            logger.debug(
+                f"开始执行任务 {func.__name__} (config_id={config_id}, task_id={real_task_id})"
+            )
+            result = await func(*args, context=context, **kwargs)
+
             # 成功时记录
             if real_task_id:
                 await _create_execution_record(
@@ -101,15 +90,19 @@ def execution_handler(func: Callable) -> Callable:
                     is_success=True,
                     started_at=start_time,
                     completed_at=datetime.utcnow(),
-                    result={"return_value": result} if result is not None else None
+                    result={"return_value": result} if result is not None else None,
                 )
-            
-            logger.debug(f"任务 {func.__name__} 执行成功 (config_id={config_id})")
+
+            logger.debug(
+                f"任务 {func.__name__} 执行成功 (config_id={config_id})"
+            )
             return result
-            
+
         except asyncio.CancelledError as e:
-            logger.error(f"任务 {func.__name__} 被取消(可能是超时) config_id={config_id}, task_id={real_task_id}: {e}")
-            
+            logger.error(
+                f"任务 {func.__name__} 被取消(可能是超时) config_id={config_id}, task_id={real_task_id}: {e}"
+            )
+
             # 取消时记录失败
             if real_task_id:
                 await _create_execution_record(
@@ -118,14 +111,16 @@ def execution_handler(func: Callable) -> Callable:
                     is_success=False,
                     started_at=start_time,
                     completed_at=datetime.utcnow(),
-                    error_message=f"任务被取消(超时): {str(e)}"
+                    error_message=f"任务被取消(超时): {str(e)}",
                 )
             raise
-            
+
         except Exception as e:
             # 处理其他异常（不包括超时）
-            logger.error(f"任务 {func.__name__} 执行失败 config_id={config_id}, task_id={real_task_id}: {e}")
-            
+            logger.error(
+                f"任务 {func.__name__} 执行失败 config_id={config_id}, task_id={real_task_id}: {e}"
+            )
+
             # 失败时记录
             if real_task_id:
                 await _create_execution_record(
@@ -134,10 +129,11 @@ def execution_handler(func: Callable) -> Callable:
                     is_success=False,
                     started_at=start_time,
                     completed_at=datetime.utcnow(),
-                    error_message=str(e)
+                    error_message=str(e),
                 )
-            
+
             # 重新抛出原始异常
             raise
-    
+
     return wrapper
+


### PR DESCRIPTION
## Summary
- accept Taskiq context directly in execution decorator
- surface execution record creation failures

## Testing
- `poetry run ruff check app/infrastructure/tasks/exec_record_decorators.py`
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68be691758888324a1c1b1d674c6e444