### PR TITLE
Refactor blocking LLM flows to async

### DIFF
--- a/backend/app/modules/llm/client.py
+++ b/backend/app/modules/llm/client.py
@@ -1,7 +1,7 @@
-from openai import OpenAI
+from openai import AsyncOpenAI
 
 from app.core.config import settings
 
 
-client = OpenAI(base_url=settings.LLM_BASE_URL, api_key=settings.LLM_API_KEY)
+client = AsyncOpenAI(base_url=settings.LLM_BASE_URL, api_key=settings.LLM_API_KEY)
 


### PR DESCRIPTION
## Summary
- offload spaCy loading, text splitting, and markdown stripping to threadpool-backed async helpers
- switch the OpenAI client to `AsyncOpenAI` and await streaming responses inside the websocket handler
- ensure websocket prompt preparation runs outside the event loop to prevent blocking

## Testing
- `PYTHONPATH=. poetry run pytest` *(fails: missing PostgresSettings configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b8385c848324a36c2dd65cc9be21