### PR TITLE
Harden LLM websocket flow with history trimming and embedding cache

### DIFF
--- a/backend/app/api/v1/endpoints/llm_ws.py
+++ b/backend/app/api/v1/endpoints/llm_ws.py
@@ -1,4 +1,8 @@
+from typing import Any, Dict, List
+
+import tiktoken
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Depends
+from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -8,6 +12,48 @@ from app.modules.llm.service import prepare_system_and_user
 from app.modules.knowledge_base.service import search_similar_chunks
 from app.api.dependencies import get_current_user_from_ws
 from app.modules.auth.models import User
+
+
+DEFAULT_HISTORY_MAX_TOKENS = 2000
+HISTORY_MAX_TOKENS = getattr(settings, "LLM_MAX_HISTORY_TOKENS", DEFAULT_HISTORY_MAX_TOKENS)
+
+
+def _encoding_for_model(model: str) -> "tiktoken.Encoding":
+    try:
+        return tiktoken.encoding_for_model(model)
+    except Exception:
+        return tiktoken.get_encoding("cl100k_base")
+
+
+def _message_token_length(message: Dict[str, Any], encoding: "tiktoken.Encoding") -> int:
+    content = message.get("content", "")
+    if not isinstance(content, str):
+        content = str(content)
+    # 估算消息 token（简单地按内容编码长度 + 常数项）
+    return len(encoding.encode(content)) + 4
+
+
+def trim_history(
+    history: List[Dict[str, Any]],
+    max_tokens: int = HISTORY_MAX_TOKENS,
+    model: str | None = None,
+) -> None:
+    """限制历史消息的 token 数，超出上限时丢弃最早的对话对。"""
+
+    if not history or max_tokens <= 0:
+        return
+
+    encoding = _encoding_for_model(model or settings.LLM_MODEL)
+    tokens_per_message = [_message_token_length(msg, encoding) for msg in history]
+    total_tokens = sum(tokens_per_message)
+
+    while history and total_tokens > max_tokens:
+        removed_tokens = tokens_per_message.pop(0)
+        removed = history.pop(0)
+        total_tokens -= removed_tokens
+        if removed.get("role") == "user" and history and history[0].get("role") == "assistant":
+            total_tokens -= tokens_per_message.pop(0)
+            history.pop(0)
 
 
 router = APIRouter(prefix="/ws", tags=["llm"])
@@ -20,7 +66,7 @@ async def ws_chat(
     db: AsyncSession = Depends(get_async_session),
 ):
     await ws.accept()
-    history: list[dict] = []
+    history: List[Dict[str, Any]] = []
     try:
         while True:
             incoming = await ws.receive_json()
@@ -29,7 +75,7 @@ async def ws_chat(
                 await ws.send_json({"type": "reset_ok"})
                 continue
 
-            user_text = (incoming.get("content") or "").strip()
+            raw_user_text = (incoming.get("content") or "").strip()
             # temperature 参数：前端可传入，默认 0.2，范围夹紧到 [0.0, 2.0]
             raw_temp = incoming.get("temperature", None)
             temperature = 0.2
@@ -42,38 +88,52 @@ async def ws_chat(
                 temperature = 0.0
             if temperature > 2.0:
                 temperature = 2.0
-            if not user_text:
+            if not raw_user_text:
                 await ws.send_json({"type": "error", "message": "empty content"})
                 continue
 
             # RAG: 检索相似上下文
             try:
-                similar = await search_similar_chunks(db, user_text, settings.RAG_TOP_K)
+                similar = await search_similar_chunks(db, raw_user_text, settings.RAG_TOP_K)
             except Exception:
                 similar = []
 
+            # 限制历史消息长度，避免上下文无限增长
+            trim_history(history, HISTORY_MAX_TOKENS, settings.LLM_MODEL)
+
             # 使用服务层根据语言构建 system_prompt 以及包裹后的 user_text
-            system_prompt, user_text = prepare_system_and_user(user_text, similar)
-
-            history.append({"role": "user", "content": user_text})
-
-            stream = client.chat.completions.create(
-                model=settings.LLM_MODEL,
-                messages=[{"role": "system", "content": system_prompt}] + history,
-                stream=True,
-                temperature=temperature,
+            system_prompt, final_user_text = await run_in_threadpool(
+                prepare_system_and_user, raw_user_text, similar
             )
 
-            acc: list[str] = []
-            for chunk in stream:
-                delta = chunk.choices[0].delta
-                token = getattr(delta, "content", None) or (delta.get("content") if isinstance(delta, dict) else None)
-                if token:
-                    acc.append(token)
-                    await ws.send_json({"type": "delta", "content": token})
+            # 构造发送给 LLM 的消息：系统提示 + 截断后的历史 + 当前带上下文的问题
+            messages: List[Dict[str, Any]] = [{"role": "system", "content": system_prompt}]
+            messages.extend(history)
+            messages.append({"role": "user", "content": final_user_text})
+
+            acc: List[str] = []
+            async with client.chat.completions.stream(
+                model=settings.LLM_MODEL,
+                messages=messages,
+                temperature=temperature,
+            ) as stream:
+                async for chunk in stream:
+                    if not getattr(chunk, "choices", None):
+                        continue
+                    delta = chunk.choices[0].delta
+                    token = None
+                    if hasattr(delta, "content"):
+                        token = delta.content
+                    elif isinstance(delta, dict):
+                        token = delta.get("content")
+                    if token:
+                        acc.append(token)
+                        await ws.send_json({"type": "delta", "content": token})
 
             text = "".join(acc)
+            history.append({"role": "user", "content": raw_user_text})
             history.append({"role": "assistant", "content": text})
+            trim_history(history, HISTORY_MAX_TOKENS, settings.LLM_MODEL)
             await ws.send_json({"type": "done"})
 
     except WebSocketDisconnect:

--- a/backend/app/modules/knowledge_base/service.py
+++ b/backend/app/modules/knowledge_base/service.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import List, Sequence
 from functools import lru_cache
+from collections import OrderedDict
+from threading import Lock
 import os
 
 from sentence_transformers import SentenceTransformer
@@ -21,13 +23,41 @@ from bs4 import BeautifulSoup
 _model = SentenceTransformer(settings.EMBEDDING_MODEL)
 
 
-@lru_cache(maxsize=8)
-def get_spacy_nlp_for_lang(lang: str):
-    """按语言惰性加载 spaCy 模型，失败返回 None。
+# 查询向量缓存，避免重复计算导致的线程池阻塞
+_QUERY_EMBED_CACHE: "OrderedDict[str, tuple[float, ...]]" = OrderedDict()
+_QUERY_EMBED_CACHE_LOCK = Lock()
+_QUERY_EMBED_CACHE_MAXSIZE = 256
 
-    优先使用对应语言的 PATH 变量，其次按模型名称加载；
-    不支持的语言回退为中文配置。
-    """
+
+def _get_cached_query_embedding(query: str) -> List[float] | None:
+    """从 LRU 缓存中读取查询向量。"""
+
+    if not query:
+        return None
+    with _QUERY_EMBED_CACHE_LOCK:
+        cached = _QUERY_EMBED_CACHE.get(query)
+        if cached is None:
+            return None
+        # 刷新 LRU 次序
+        _QUERY_EMBED_CACHE.move_to_end(query)
+        return list(cached)
+
+
+def _store_cached_query_embedding(query: str, embedding: Sequence[float]) -> None:
+    """存储查询向量到缓存中，维持 LRU 容量。"""
+
+    if not query:
+        return
+    with _QUERY_EMBED_CACHE_LOCK:
+        _QUERY_EMBED_CACHE[query] = tuple(float(x) for x in embedding)
+        _QUERY_EMBED_CACHE.move_to_end(query)
+        if len(_QUERY_EMBED_CACHE) > _QUERY_EMBED_CACHE_MAXSIZE:
+            _QUERY_EMBED_CACHE.popitem(last=False)
+
+
+@lru_cache(maxsize=8)
+def _get_spacy_nlp_for_lang(lang: str):
+    """按语言惰性加载 spaCy 模型，失败返回 None。"""
     try:
         import spacy  # type: ignore
         language = (lang or "").lower().strip()
@@ -54,7 +84,12 @@ def get_spacy_nlp_for_lang(lang: str):
         return None
 
 
-def split_text(content: str, target: int = 300, overlap: int = 50) -> List[str]:
+async def get_spacy_nlp_for_lang(lang: str):
+    """在线程池中加载 spaCy 模型以避免阻塞事件循环。"""
+    return await run_in_threadpool(_get_spacy_nlp_for_lang, lang)
+
+
+def _split_text_sync(content: str, target: int = 300, overlap: int = 50) -> List[str]:
     """按句分块（自动检测语言，优先使用对应 spaCy 模型分句）。
 
     - target: 目标块大小（约字符数）
@@ -82,7 +117,7 @@ def split_text(content: str, target: int = 300, overlap: int = 50) -> List[str]:
         lang = "en"
 
     sentences: List[str]
-    nlp = get_spacy_nlp_for_lang(lang)
+    nlp = _get_spacy_nlp_for_lang(lang)
     if nlp is not None and text:
         try:
             doc = nlp(text)
@@ -122,7 +157,12 @@ def split_text(content: str, target: int = 300, overlap: int = 50) -> List[str]:
     return chunks or ([text] if text else [])
 
 
-def _strip_markdown(content: str) -> str:
+async def split_text(content: str, target: int = 300, overlap: int = 50) -> List[str]:
+    """在线程池中执行分句逻辑，避免阻塞事件循环。"""
+    return await run_in_threadpool(_split_text_sync, content, target, overlap)
+
+
+def _strip_markdown_sync(content: str) -> str:
     """将 Markdown 文本转换为纯文本。
 
     策略：先用 markdown 库转 HTML，再用 BeautifulSoup 提取纯文本；
@@ -155,6 +195,11 @@ def _strip_markdown(content: str) -> str:
     return "\n".join(lines)
 
 
+async def _strip_markdown(content: str) -> str:
+    """在线程池中清洗 Markdown 内容，避免阻塞事件循环。"""
+    return await run_in_threadpool(_strip_markdown_sync, content)
+
+
 async def create_document(db: AsyncSession, data: KnowledgeDocumentCreate) -> models.KnowledgeDocument:
     doc = models.KnowledgeDocument(
         source_type=data.source_type,
@@ -175,18 +220,17 @@ async def create_document(db: AsyncSession, data: KnowledgeDocumentCreate) -> mo
 async def ingest_document_content(db: AsyncSession, document_id: int, content: str, overwrite: bool = False) -> int:
     """将文本切分并写入指定文档的知识块，返回块数量。
 
-    注意：split_text 与 _model.encode 为同步且可能耗时的 CPU 密集操作，
-    放入线程池以避免阻塞事件循环。
+    注意：文本清洗、分句与向量编码均在线程池中执行，以避免阻塞事件循环。
     """
     # 新增步骤：在所有操作之前，先清理传入的 content
-    plain_text_content = _strip_markdown(content)
+    plain_text_content = await _strip_markdown(content)
 
     # 根据覆盖标志，先删除旧分块，避免数据冗余
     if overwrite:
         await db.execute(delete(models.KnowledgeChunk).where(models.KnowledgeChunk.document_id == document_id))
 
     # 在线程池中进行分句（使用清理后的纯文本）
-    chunks = await run_in_threadpool(split_text, plain_text_content)
+    chunks = await split_text(plain_text_content)
     if not chunks:
         # 若选择覆盖且新内容为空，确保删除提交
         if overwrite:
@@ -210,10 +254,17 @@ async def delete_document(db: AsyncSession, document_id: int) -> None:
 async def search_similar_chunks(db: AsyncSession, query: str, top_k: int):
     """按余弦距离检索最相似的知识块。
 
-    _model.encode 为同步且可能耗时，放入线程池执行。
+    为减少重复向量化带来的阻塞，优先命中缓存，未命中再回退线程池计算。
     """
-    # 在线程池中进行查询向量编码
-    q_emb = (await run_in_threadpool(_model.encode, [query], normalize_embeddings=True))[0]
+    cached = _get_cached_query_embedding(query)
+    if cached is not None:
+        q_emb = cached
+    else:
+        # 在线程池中进行查询向量编码
+        vectors = await run_in_threadpool(_model.encode, [query], normalize_embeddings=True)
+        arr = vectors[0]
+        q_emb = arr.tolist() if hasattr(arr, "tolist") else list(arr)
+        _store_cached_query_embedding(query, q_emb)
     stmt = (
         select(models.KnowledgeChunk)
         .order_by(models.KnowledgeChunk.embedding.cosine_distance(q_emb))

--- a/backend/app/modules/llm/client.py
+++ b/backend/app/modules/llm/client.py
@@ -1,7 +1,7 @@
-from openai import OpenAI
+from openai import AsyncOpenAI
 
 from app.core.config import settings
 
 
-client = OpenAI(base_url=settings.LLM_BASE_URL, api_key=settings.LLM_API_KEY)
+client = AsyncOpenAI(base_url=settings.LLM_BASE_URL, api_key=settings.LLM_API_KEY)
 


### PR DESCRIPTION
## Summary
- offload spaCy loading, text splitting, and markdown stripping to threadpool-backed async helpers
- switch the OpenAI client to AsyncOpenAI and await streaming responses inside the websocket handler with an async context manager
- ensure websocket prompt preparation runs outside the event loop to prevent blocking
- add token-aware history trimming that keeps prior RAG context out of persisted chat messages
- introduce an LRU cache for query embeddings to avoid repeated SentenceTransformer work during retrieval

## Testing
- `PYTHONPATH=. poetry run pytest` *(fails: missing PostgresSettings configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b8385c848324a36c2dd65cc9be21