### PR TITLE
Update LLM websocket handler

### DIFF
--- a/backend/app/api/v1/endpoints/llm_ws.py
+++ b/backend/app/api/v1/endpoints/llm_ws.py
@@ -10,12 +10,17 @@ from app.modules.knowledge_base.service import search_similar_chunks
 from app.api.dependencies import get_current_user_from_ws
 from app.modules.auth.models import User
 
-
 router = APIRouter(prefix="/ws", tags=["llm"])
 
-
+# 控制历史长度，避免上下文过大
 MAX_HISTORY_MESSAGES = 15
 
+def _clamp_temperature(raw) -> float:
+    try:
+        t = float(raw)
+    except (TypeError, ValueError):
+        return 0.2
+    return max(0.0, min(2.0, t))
 
 @router.websocket("/chat")
 async def ws_chat(
@@ -25,68 +30,83 @@ async def ws_chat(
 ):
     await ws.accept()
     history: list[dict] = []
+
     try:
         while True:
             incoming = await ws.receive_json()
+
+            # 客户端请求清空会话
             if incoming.get("type") == "reset":
                 history.clear()
                 await ws.send_json({"type": "reset_ok"})
                 continue
 
             user_text = (incoming.get("content") or "").strip()
-            # temperature 参数：前端可传入，默认 0.2，范围夹紧到 [0.0, 2.0]
-            raw_temp = incoming.get("temperature", None)
-            temperature = 0.2
-            if raw_temp is not None:
-                try:
-                    temperature = float(raw_temp)
-                except (TypeError, ValueError):
-                    temperature = 0.2
-            if temperature < 0.0:
-                temperature = 0.0
-            if temperature > 2.0:
-                temperature = 2.0
             if not user_text:
                 await ws.send_json({"type": "error", "message": "empty content"})
                 continue
 
-            # RAG: 检索相似上下文
+            temperature = _clamp_temperature(incoming.get("temperature", None))
+
+            # RAG: 检索相似上下文（失败时回退为空）
             try:
                 similar = await search_similar_chunks(db, user_text, settings.RAG_TOP_K)
             except Exception:
                 similar = []
 
-            # 使用服务层根据语言构建 system_prompt 以及包裹后的 user_text
-            system_prompt, user_text = await run_in_threadpool(prepare_system_and_user, user_text, similar)
+            # 由服务层生成 system_prompt，并对 user_text 做包装（语言/模板等）
+            system_prompt, wrapped_user_text = await run_in_threadpool(
+                prepare_system_and_user, user_text, similar
+            )
 
-            history.append({"role": "user", "content": user_text})
+            # 追加到历史（只保留最近 N 条）
+            history.append({"role": "user", "content": wrapped_user_text})
             if len(history) > MAX_HISTORY_MESSAGES:
                 del history[:-MAX_HISTORY_MESSAGES]
 
+            # —— OpenAI Chat Completions：异步流式 —— 
+            # 官方模式：create(..., stream=True) → async for chunk in stream
+            # 参考：openai-python README / 社区示例
+            # 可选：开启用量统计（视服务端实现而定）
+            # stream_options = {"include_usage": True}
             acc: list[str] = []
-            async with client.chat.completions.stream(
-                model=settings.LLM_MODEL,
-                messages=[{"role": "system", "content": system_prompt}] + history,
-                temperature=temperature,
-            ) as stream:
-                async for event in stream:
-                    # 1. 智能地解包，处理 ChunkEvent 包装器或原始 Chunk 对象
-                    chunk = getattr(event, "chunk", event)
-                    
-                    # 2. 安全且清晰地访问 token 内容
-                    # openai v1+ 保证了 chunk.choices 是一个列表
-                    if chunk.choices:
-                        delta = chunk.choices[0].delta
-                        token = delta.content
-                        if token:
-                            acc.append(token)
-                            await ws.send_json({"type": "delta", "content": token})
+            try:
+                stream = await client.chat.completions.create(
+                    model=settings.LLM_MODEL,
+                    messages=[{"role": "system", "content": system_prompt}] + history,
+                    temperature=temperature,
+                    stream=True,
+                    # stream_options=stream_options,  # 如需用量统计再开启
+                )
 
-            text = "".join(acc)
-            history.append({"role": "assistant", "content": text})
-            if len(history) > MAX_HISTORY_MESSAGES:
-                del history[:-MAX_HISTORY_MESSAGES]
-            await ws.send_json({"type": "done"})
+                async for chunk in stream:
+                    # 防御性判空：choices 可能为空；首块 delta 可能只有 role
+                    if not getattr(chunk, "choices", None):
+                        continue
+                    choice = chunk.choices[0]
+                    delta = getattr(choice, "delta", None)
+                    if not delta:
+                        continue
+
+                    token = getattr(delta, "content", None)
+                    if token:
+                        acc.append(token)
+                        await ws.send_json({"type": "delta", "content": token})
+
+                # 结束：汇总文本，入历史
+                text = "".join(acc)
+                history.append({"role": "assistant", "content": text})
+                if len(history) > MAX_HISTORY_MESSAGES:
+                    del history[:-MAX_HISTORY_MESSAGES]
+
+                await ws.send_json({"type": "done"})
+
+            except Exception as e:
+                # 将错误回传给前端，便于 UI 做降级提示
+                await ws.send_json(
+                    {"type": "error", "message": f"stream_failed: {e.__class__.__name__}"}
+                )
 
     except WebSocketDisconnect:
-        pass
+        # 客户端断开，静默结束
+        return


### PR DESCRIPTION
## Summary
- clamp temperature inputs via helper and ensure blank user messages are rejected early
- wrap user text via service layer and streamline streaming completions handling with defensive checks
- report stream errors back to the websocket client while maintaining bounded chat history

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8fe56639c832486b9d0c2b0af138f