### PR TITLE
Fix Redis health check lock and llama health probe

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -317,7 +317,7 @@ services:
     expose:
       - "8080"
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8080/slots >/dev/null || curl -fsS http://127.0.0.1:8080/v1/models >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "curl -fsS -H \"Authorization: Bearer ${LLM_API_KEY}\" http://127.0.0.1:8080/slots >/dev/null || curl -fsS http://127.0.0.1:8080/v1/models >/dev/null || exit 1"]
       interval: 15s
       timeout: 5s
       retries: 8


### PR DESCRIPTION
## Summary
- lazily create the Redis health-check lock during initialize to avoid event-loop errors when importing
- ensure the periodic health check always has a lock instance before use
- update the llama_server health probe to include the API key when querying /slots

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca2de3b1d88324877cd92a284a4a1b