### PR TITLE
update match service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,14 +108,26 @@ HF_REVISION=main
 HF_HUB_ENABLE_HF_TRANSFER=1
 EMBEDDING_MODEL=sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2
 RAG_TOP_K=3
+RAG_MIN_SIM=0.4
+RAG_MMR_LAMBDA=0.6
+RAG_PER_DOC_LIMIT=5
+RAG_OVERSAMPLE=5
+RAG_MAX_CANDIDATES=100
+RAG_SAME_LANG_BONUS=0.12
+RAG_CONTEXT_TOKEN_BUDGET=2400
+RAG_CONTEXT_MAX_EVIDENCE=12
+RAG_CHUNK_TARGET_TOKENS_EN=260
+RAG_CHUNK_TARGET_TOKENS_CJK=420
+RAG_CHUNK_TARGET_TOKENS_DEFAULT=320
+RAG_CHUNK_OVERLAP_RATIO=0.15
+RAG_CODE_CHUNK_MAX_LINES=40
+RAG_CODE_CHUNK_OVERLAP_LINES=6
+RAG_IVFFLAT_PROBES=10
 
 # === spaCy 多语言小模型（用于分句）===
-SPACY_MODEL_ZH=zh_core_web_sm
 SPACY_MODEL_EN=en_core_web_sm
-SPACY_MODEL_JA=ja_core_news_sm
+SPACY_MODEL_URL=https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
 
 # 预下载模型 URL 列表（与镜像内 spaCy 版本兼容）
-SPACY_MODEL_URLS=https://github.com/explosion/spacy-models/releases/download/zh_core_web_sm-3.8.0/zh_core_web_sm-3.8.0-py3-none-any.whl,https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl,https://github.com/explosion/spacy-models/releases/download/ja_core_news_sm-3.8.0/ja_core_news_sm-3.8.0-py3-none-any.whl
 
 # 单个 URL（向后兼容，不再推荐）
-#SPACY_MODEL_URL=https://github.com/explosion/spacy-models/releases/download/zh_core_web_sm-3.8.0/zh_core_web_sm-3.8.0-py3-none-any.whl

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -113,14 +113,26 @@ HF_REVISION=main
 HF_HUB_ENABLE_HF_TRANSFER=1
 EMBEDDING_MODEL=sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2
 RAG_TOP_K=3
+RAG_MIN_SIM=0.4
+RAG_MMR_LAMBDA=0.6
+RAG_PER_DOC_LIMIT=5
+RAG_OVERSAMPLE=5
+RAG_MAX_CANDIDATES=100
+RAG_SAME_LANG_BONUS=0.12
+RAG_CONTEXT_TOKEN_BUDGET=2400
+RAG_CONTEXT_MAX_EVIDENCE=12
+RAG_CHUNK_TARGET_TOKENS_EN=260
+RAG_CHUNK_TARGET_TOKENS_CJK=420
+RAG_CHUNK_TARGET_TOKENS_DEFAULT=320
+RAG_CHUNK_OVERLAP_RATIO=0.15
+RAG_CODE_CHUNK_MAX_LINES=40
+RAG_CODE_CHUNK_OVERLAP_LINES=6
+RAG_IVFFLAT_PROBES=10
 
 # === spaCy 多语言小模型（用于分句）===
-SPACY_MODEL_ZH=zh_core_web_sm
 SPACY_MODEL_EN=en_core_web_sm
-SPACY_MODEL_JA=ja_core_news_sm
+SPACY_MODEL_URL=https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
 
 # 预下载模型 URL 列表（与镜像内 spaCy 版本兼容）
-SPACY_MODEL_URLS=https://github.com/explosion/spacy-models/releases/download/zh_core_web_sm-3.8.0/zh_core_web_sm-3.8.0-py3-none-any.whl,https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl,https://github.com/explosion/spacy-models/releases/download/ja_core_news_sm-3.8.0/ja_core_news_sm-3.8.0-py3-none-any.whl
 
 # 单个 URL（向后兼容，不再推荐）
-#SPACY_MODEL_URL=https://github.com/explosion/spacy-models/releases/download/zh_core_web_sm-3.8.0/zh_core_web_sm-3.8.0-py3-none-any.whl

--- a/backend/alembic/versions/7c2e9e5f3b92_add_language_to_chunks.py
+++ b/backend/alembic/versions/7c2e9e5f3b92_add_language_to_chunks.py
@@ -1,0 +1,29 @@
+"""add language column to knowledge_chunks
+
+Revision ID: 7c2e9e5f3b92
+Revises: 3f9a9b1a7a00
+Create Date: 2025-01-30 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "7c2e9e5f3b92"
+down_revision: Union[str, None] = "3f9a9b1a7a00"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "knowledge_chunks",
+        sa.Column("language", sa.String(length=16), nullable=True, comment="块语言/类型"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("knowledge_chunks", "language")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -354,14 +354,24 @@ class Settings(BaseSettings):
     LLM_MODEL: str = Field(default_factory=lambda: os.getenv("HF_FILENAME", "gemma-3-4b-it-q4_0.gguf"))
     EMBEDDING_MODEL: str = Field(default="sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2")
     RAG_TOP_K: int = Field(default=3)
-    # spaCy 模型配置（多语言）
-    # 按语言分别配置小模型与可选路径
-    SPACY_MODEL_ZH: str = Field(default="zh_core_web_sm")
+    RAG_MIN_SIM: float = Field(default=0.4)
+    RAG_MMR_LAMBDA: float = Field(default=0.6)
+    RAG_PER_DOC_LIMIT: int = Field(default=1)
+    RAG_OVERSAMPLE: int = Field(default=5)
+    RAG_MAX_CANDIDATES: int = Field(default=100)
+    RAG_SAME_LANG_BONUS: float = Field(default=0.12)
+    RAG_CONTEXT_TOKEN_BUDGET: int = Field(default=2000)
+    RAG_CONTEXT_MAX_EVIDENCE: int = Field(default=12)
+    RAG_CHUNK_TARGET_TOKENS_EN: int = Field(default=260)
+    RAG_CHUNK_TARGET_TOKENS_CJK: int = Field(default=420)
+    RAG_CHUNK_TARGET_TOKENS_DEFAULT: int = Field(default=320)
+    RAG_CHUNK_OVERLAP_RATIO: float = Field(default=0.15)
+    RAG_CODE_CHUNK_MAX_LINES: int = Field(default=40)
+    RAG_CODE_CHUNK_OVERLAP_LINES: int = Field(default=6)
+    RAG_IVFFLAT_PROBES: int = Field(default=10)
+    # spaCy 英文模型配置（保留轻量模型路径以便自定义）
     SPACY_MODEL_EN: str = Field(default="en_core_web_sm")
-    SPACY_MODEL_JA: str = Field(default="ja_core_news_sm")
-    SPACY_MODEL_PATH_ZH: str | None = Field(default=None)
     SPACY_MODEL_PATH_EN: str | None = Field(default=None)
-    SPACY_MODEL_PATH_JA: str | None = Field(default=None)
 
     model_config = SettingsConfigDict(
         case_sensitive=True,

--- a/backend/app/modules/knowledge_base/models.py
+++ b/backend/app/modules/knowledge_base/models.py
@@ -47,6 +47,7 @@ class KnowledgeChunk(Base):
     content: Mapped[str] = mapped_column(Text, nullable=False, comment="文本内容")
     # 384 维向量，需与所选嵌入模型维度一致
     embedding: Mapped[List[float]] = mapped_column(Vector(dim=384), nullable=False, comment="向量表示")
+    language: Mapped[Optional[str]] = mapped_column(String(16), nullable=True, comment="块语言/类型")
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
 
     document: Mapped[Optional[KnowledgeDocument]] = relationship(back_populates="chunks")

--- a/backend/app/modules/knowledge_base/repository.py
+++ b/backend/app/modules/knowledge_base/repository.py
@@ -1,119 +1,172 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Iterable, Optional, Sequence
+
+import numpy as np
 
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from . import models
 from .schemas import KnowledgeDocumentCreate
 
 
-async def create_document(
-    db: AsyncSession, data: KnowledgeDocumentCreate
-) -> models.KnowledgeDocument:
-    """Persist a new knowledge document without committing."""
-    doc = models.KnowledgeDocument(
-        source_type=data.source_type,
-        source_ref=data.source_ref,
-        title=data.title,
-        language=data.language,
-        mime=data.mime,
-        checksum=data.checksum,
-        meta=data.meta,
-        tags=data.tags,
-        created_by=data.created_by,
-    )
-    db.add(doc)
-    await db.flush()
-    return doc
+class CRUDKnowledgeBase:
+    """Repository wrapper for knowledge documents and chunks."""
+
+    async def create_document(
+        self, db: AsyncSession, data: KnowledgeDocumentCreate
+    ) -> models.KnowledgeDocument:
+        """Persist a new knowledge document (without commit)."""
+        doc = models.KnowledgeDocument(
+            source_type=data.source_type,
+            source_ref=data.source_ref,
+            title=data.title,
+            language=data.language,
+            mime=data.mime,
+            checksum=data.checksum,
+            meta=data.meta,
+            tags=data.tags,
+            created_by=data.created_by,
+        )
+        db.add(doc)
+        await db.flush()
+        return doc
+
+    async def delete_document(self, db: AsyncSession, document_id: int) -> None:
+        """Remove a document and cascade to its chunks."""
+        await db.execute(
+            delete(models.KnowledgeDocument).where(models.KnowledgeDocument.id == document_id)
+        )
+        await db.commit()
+
+    async def get_all_documents(
+        self, db: AsyncSession, skip: int = 0, limit: int = 100
+    ) -> list[models.KnowledgeDocument]:
+        stmt = (
+            select(models.KnowledgeDocument)
+            .order_by(models.KnowledgeDocument.created_at.desc())
+            .offset(skip)
+            .limit(limit)
+        )
+        result = await db.scalars(stmt)
+        return result.all()
+
+    async def get_document_by_id(
+        self, db: AsyncSession, document_id: int
+    ) -> Optional[models.KnowledgeDocument]:
+        return await db.get(models.KnowledgeDocument, document_id)
+
+    async def update_document_metadata(
+        self, db: AsyncSession, document_id: int, updates: dict
+    ) -> Optional[models.KnowledgeDocument]:
+        doc = await db.get(models.KnowledgeDocument, document_id)
+        if not doc:
+            return None
+
+        allowed_fields = {
+            "source_type",
+            "source_ref",
+            "title",
+            "language",
+            "mime",
+            "checksum",
+            "meta",
+            "tags",
+            "created_by",
+        }
+
+        for key, value in (updates or {}).items():
+            if key in allowed_fields:
+                setattr(doc, key, value)
+
+        await db.commit()
+        await db.refresh(doc)
+        return doc
+
+    async def get_chunks_by_document_id(
+        self, db: AsyncSession, document_id: int
+    ) -> list[models.KnowledgeChunk]:
+        stmt = (
+            select(models.KnowledgeChunk)
+            .where(models.KnowledgeChunk.document_id == document_id)
+            .order_by(models.KnowledgeChunk.chunk_index.asc(), models.KnowledgeChunk.id.asc())
+        )
+        result = await db.scalars(stmt)
+        return result.all()
+
+    async def delete_chunks_by_document_id(
+        self, db: AsyncSession, document_id: int, *, commit: bool = False
+    ) -> None:
+        await db.execute(
+            delete(models.KnowledgeChunk).where(models.KnowledgeChunk.document_id == document_id)
+        )
+        if commit:
+            await db.commit()
+
+    async def bulk_create_document_chunks(
+        self,
+        db: AsyncSession,
+        document_id: int,
+        chunks: Iterable[tuple[int, str, Sequence[float], Optional[str]]],
+        *,
+        commit: bool = True,
+    ) -> int:
+        """Persist a batch of chunks for a document."""
+
+        created = 0
+        for chunk_index, content, embedding, language in chunks:
+            db.add(
+                models.KnowledgeChunk(
+                    document_id=document_id,
+                    chunk_index=chunk_index,
+                    content=content,
+                    embedding=np.asarray(embedding),
+                    language=language,
+                )
+            )
+            created += 1
+
+        if commit:
+            await db.commit()
+        else:
+            await db.flush()
+
+        return created
+
+    async def get_chunk_by_id(
+        self, db: AsyncSession, chunk_id: int
+    ) -> Optional[models.KnowledgeChunk]:
+        return await db.get(models.KnowledgeChunk, chunk_id)
+
+    async def persist_chunk(
+        self, db: AsyncSession, chunk: models.KnowledgeChunk
+    ) -> models.KnowledgeChunk:
+        await db.commit()
+        await db.refresh(chunk)
+        return chunk
+
+    async def delete_chunk(self, db: AsyncSession, chunk: models.KnowledgeChunk) -> None:
+        await db.delete(chunk)
+        await db.commit()
+
+    async def fetch_chunk_candidates_by_embedding(
+        self,
+        db: AsyncSession,
+        query_embedding: np.ndarray,
+        limit: int,
+    ):
+        distance_expr = models.KnowledgeChunk.embedding.cosine_distance(query_embedding)
+        stmt = (
+            select(models.KnowledgeChunk, distance_expr.label("distance"))
+            .options(selectinload(models.KnowledgeChunk.document))
+            .order_by(distance_expr.asc())
+            .limit(limit)
+        )
+
+        rows = await db.execute(stmt)
+        return rows.all()
 
 
-async def delete_document(db: AsyncSession, document_id: int) -> None:
-    """Remove a document and cascade to its chunks."""
-    await db.execute(
-        delete(models.KnowledgeDocument).where(models.KnowledgeDocument.id == document_id)
-    )
-    await db.commit()
-
-
-async def get_all_documents(
-    db: AsyncSession, skip: int = 0, limit: int = 100
-) -> list[models.KnowledgeDocument]:
-    stmt = (
-        select(models.KnowledgeDocument)
-        .order_by(models.KnowledgeDocument.created_at.desc())
-        .offset(skip)
-        .limit(limit)
-    )
-    result = await db.scalars(stmt)
-    return result.all()
-
-
-async def get_document_by_id(
-    db: AsyncSession, document_id: int
-) -> Optional[models.KnowledgeDocument]:
-    return await db.get(models.KnowledgeDocument, document_id)
-
-
-async def update_document_metadata(
-    db: AsyncSession, document_id: int, updates: dict
-) -> Optional[models.KnowledgeDocument]:
-    doc = await db.get(models.KnowledgeDocument, document_id)
-    if not doc:
-        return None
-
-    allowed_fields = {
-        "source_type",
-        "source_ref",
-        "title",
-        "language",
-        "mime",
-        "checksum",
-        "meta",
-        "tags",
-        "created_by",
-    }
-
-    for key, value in (updates or {}).items():
-        if key in allowed_fields:
-            setattr(doc, key, value)
-
-    await db.commit()
-    await db.refresh(doc)
-    return doc
-
-
-async def get_chunks_by_document_id(
-    db: AsyncSession, document_id: int
-) -> list[models.KnowledgeChunk]:
-    stmt = (
-        select(models.KnowledgeChunk)
-        .where(models.KnowledgeChunk.document_id == document_id)
-        .order_by(models.KnowledgeChunk.chunk_index.asc(), models.KnowledgeChunk.id.asc())
-    )
-    result = await db.scalars(stmt)
-    return result.all()
-
-
-async def delete_chunks_by_document_id(db: AsyncSession, document_id: int) -> None:
-    await db.execute(
-        delete(models.KnowledgeChunk).where(models.KnowledgeChunk.document_id == document_id)
-    )
-
-
-async def get_chunk_by_id(
-    db: AsyncSession, chunk_id: int
-) -> Optional[models.KnowledgeChunk]:
-    return await db.get(models.KnowledgeChunk, chunk_id)
-
-
-async def persist_chunk(db: AsyncSession, chunk: models.KnowledgeChunk) -> models.KnowledgeChunk:
-    await db.commit()
-    await db.refresh(chunk)
-    return chunk
-
-
-async def delete_chunk(db: AsyncSession, chunk: models.KnowledgeChunk) -> None:
-    await db.delete(chunk)
-    await db.commit()
+crud_knowledge_base = CRUDKnowledgeBase()

--- a/backend/app/modules/knowledge_base/schemas.py
+++ b/backend/app/modules/knowledge_base/schemas.py
@@ -49,6 +49,7 @@ class KnowledgeChunkRead(BaseModel):
     document_id: Optional[int] = None
     chunk_index: Optional[int] = None
     content: str
+    language: Optional[str] = None
     created_at: datetime
 
     model_config = {"from_attributes": True}
@@ -59,6 +60,7 @@ class KnowledgeChunkUpdate(BaseModel):
     chunk_index: Optional[int] = Field(
         None, description="文档内块序，允许为空表示未指定"
     )
+    language: Optional[str] = Field(None, description="块语言，通常自动推断")
 
 
 class KnowledgeSearchRequest(BaseModel):

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -92,13 +92,11 @@ services:
         condition: service_completed_successfully
     command: >
       bash -c "
-        URLS=\"$${SPACY_MODEL_URLS:-$${SPACY_MODEL_URL}}\" &&
+        MODEL_URL=\"$${SPACY_MODEL_URL}\" &&
+        MODEL_FILE=$$(basename \"$${MODEL_URL}\") &&
         echo '安装本地 spaCy 模型...' &&
-        for U in $$(echo \"$${URLS}\" | tr ',' ' '); do \
-          F=$$(basename \"$${U}\"); \
-          echo \" - pip install /models/$${F}\"; \
-          poetry run pip install /models/$${F} || true; \
-        done &&
+        echo \" - pip install /models/$${MODEL_FILE}\" &&
+        poetry run pip install /models/$${MODEL_FILE} || true &&
         echo '等待数据库准备...' &&
         echo '应用数据库迁移...' &&
         poetry run alembic upgrade head &&
@@ -255,7 +253,7 @@ services:
     env_file:
       - .env.dev
     environment:
-      - SPACY_MODEL_URLS=${SPACY_MODEL_URLS}
+      - SPACY_MODEL_URL=${SPACY_MODEL_URL}
       - PIP_NO_CACHE_DIR=1
       - PIP_DEFAULT_TIMEOUT=1200
     command: ["sh", "/entry-scripts/spacy_init.sh"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -138,13 +138,11 @@ services:
         condition: service_completed_successfully
     command: >
       bash -c "
-        URLS=\"$${SPACY_MODEL_URLS:-$${SPACY_MODEL_URL}}\" &&
+        MODEL_URL=\"$${SPACY_MODEL_URL}\" &&
+        MODEL_FILE=$$(basename \"$${MODEL_URL}\") &&
         echo '安装本地 spaCy 模型...' &&
-        for U in $$(echo \"$${URLS}\" | tr ',' ' '); do \
-          F=$$(basename \"$${U}\"); \
-          echo \" - pip install /models/$${F}\"; \
-          pip install /models/$${F} || true; \
-        done &&
+        echo \" - pip install /models/$${MODEL_FILE}\" &&
+        pip install /models/$${MODEL_FILE} || true &&
         echo '等待数据库准备...' &&
         echo '应用数据库迁移...' &&
         alembic upgrade head &&
@@ -260,7 +258,7 @@ services:
     env_file:
       - .env.prod
     environment:
-      - SPACY_MODEL_URLS=${SPACY_MODEL_URLS}
+      - SPACY_MODEL_URL=${SPACY_MODEL_URL}
       - PIP_NO_CACHE_DIR=1
       - PIP_DEFAULT_TIMEOUT=1200
     command: ["sh", "/entry-scripts/spacy_init.sh"]
@@ -307,7 +305,7 @@ services:
       - --host
       - 0.0.0.0
       - --ctx-size
-      - "16384"
+      - "8192"
       - --parallel
       - "2"
       - --api-key

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,17 +1,48 @@
-import { useEffect, useRef, useState } from 'react'
-import { Box, Button, Paper, Slider, Stack, TextField, Typography } from '@mui/material'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Box, Button, Paper, Popover, Slider, Stack, TextField, Typography } from '@mui/material'
 import { useAuthStore } from '../stores/auth-store'
 import ManagementLayout from '../components/Layout/ManagementLayout'
 import { renderMarkdownToHtml } from '../utils/markdown'
 
+type CitationItem = {
+  key: string
+  chunkId: number | null
+  documentId: number | null
+  chunkIndex: number | null
+  title?: string | null
+  sourceRef?: string | null
+  similarity?: number | null
+  content: string
+}
+
+type ChatMessage = {
+  role: 'user' | 'assistant'
+  content: string
+  citations?: CitationItem[]
+}
+
+type CitationPayload = {
+  key?: string
+  chunk_id?: number | null
+  document_id?: number | null
+  chunk_index?: number | null
+  title?: string | null
+  source_ref?: string | null
+  similarity?: number | null
+  content?: string
+}
+
 export default function ChatPage() {
   const wsRef = useRef<WebSocket | null>(null)
-  const [messages, setMessages] = useState<{ role: 'user' | 'assistant'; content: string }[]>([])
+  const [messages, setMessages] = useState<ChatMessage[]>([])
   const [input, setInput] = useState('')
   const [loading, setLoading] = useState(false)
-  const [temperature, setTemperature] = useState<number>(0.2)
+  const [temperature, setTemperature] = useState<number>(0.5)
   const bottomRef = useRef<HTMLDivElement | null>(null)
   const accessToken = useAuthStore((s) => s.accessToken)
+  const [citationAnchor, setCitationAnchor] = useState<HTMLElement | null>(null)
+  const [activeMessageIndex, setActiveMessageIndex] = useState<number | null>(null)
+  const [activeCitationKey, setActiveCitationKey] = useState<string | null>(null)
 
   useEffect(() => {
     const base = (import.meta.env.VITE_API_URL || '').replace(/^http/, 'ws') + '/v1/ws/chat'
@@ -20,18 +51,69 @@ export default function ChatPage() {
     wsRef.current = ws
     ws.onmessage = (ev) => {
       const data = JSON.parse(ev.data)
+      if (data.type === 'citations') {
+        const rawItems: CitationPayload[] = Array.isArray(data.items) ? data.items : []
+        const items = rawItems.reduce<CitationItem[]>((acc, item) => {
+          const key = item.key ?? ''
+          if (!key) {
+            return acc
+          }
+          acc.push({
+            key,
+            chunkId: item.chunk_id ?? null,
+            documentId: item.document_id ?? null,
+            chunkIndex: item.chunk_index ?? null,
+            title: item.title ?? null,
+            sourceRef: item.source_ref ?? null,
+            similarity: item.similarity ?? null,
+            content: item.content ?? '',
+          })
+          return acc
+        }, [])
+
+        setMessages((prev) => {
+          if (!prev.length) return prev
+          const next = prev.slice()
+          const lastIndex = next.length - 1
+          const last = next[lastIndex]
+          if (last && last.role === 'assistant') {
+            next[lastIndex] = { ...last, citations: items }
+          }
+          return next
+        })
+        return
+      }
+
       if (data.type === 'delta') {
         setMessages((prev) => {
-          const last = prev[prev.length - 1]
-          if (last && last.role === 'assistant') {
-            const copy = prev.slice()
-            copy[copy.length - 1] = { role: 'assistant', content: last.content + data.content }
-            return copy
+          if (!prev.length) {
+            return [{ role: 'assistant', content: data.content }]
           }
-          return [...prev, { role: 'assistant', content: data.content }]
+          const copy = prev.slice()
+          const lastIndex = copy.length - 1
+          const last = copy[lastIndex]
+          if (last && last.role === 'assistant') {
+            copy[lastIndex] = { ...last, content: (last.content || '') + data.content }
+          } else {
+            copy.push({ role: 'assistant', content: data.content })
+          }
+          return copy
         })
       } else if (data.type === 'done') {
         setLoading(false)
+        setCitationAnchor(null)
+        setActiveCitationKey(null)
+        setActiveMessageIndex(null)
+      } else if (data.type === 'error') {
+        setLoading(false)
+        setCitationAnchor(null)
+        setActiveCitationKey(null)
+        setActiveMessageIndex(null)
+      } else if (data.type === 'reset_ok') {
+        setLoading(false)
+        setCitationAnchor(null)
+        setActiveCitationKey(null)
+        setActiveMessageIndex(null)
       }
     }
     ws.onclose = () => {}
@@ -46,12 +128,34 @@ export default function ChatPage() {
   const send = () => {
     const text = input.trim()
     if (!text || !wsRef.current) return
-    setMessages((m) => [...m, { role: 'user', content: text }])
-    setMessages((m) => [...m, { role: 'assistant', content: '' }])
+    setMessages((prev) => [...prev, { role: 'user', content: text }, { role: 'assistant', content: '' }])
     setLoading(true)
     wsRef.current.send(JSON.stringify({ content: text, temperature }))
     setInput('')
   }
+
+  const handleCitationClick = (event: React.MouseEvent<HTMLElement>, messageIndex: number) => {
+    const target = event.target as HTMLElement | null
+    const citeEl = target?.closest('[data-cite-key]') as HTMLElement | null
+    if (!citeEl) return
+    const citeKey = citeEl.dataset.citeKey
+    if (!citeKey) return
+    event.preventDefault()
+    setCitationAnchor(citeEl)
+    setActiveMessageIndex(messageIndex)
+    setActiveCitationKey(citeKey)
+  }
+
+  const closeCitation = () => {
+    setCitationAnchor(null)
+    setActiveMessageIndex(null)
+    setActiveCitationKey(null)
+  }
+
+  const activeCitation = useMemo(() => {
+    if (activeMessageIndex === null || !activeCitationKey) return undefined
+    return messages[activeMessageIndex]?.citations?.find((c) => c.key === activeCitationKey)
+  }, [activeCitationKey, activeMessageIndex, messages])
 
   return (
     <ManagementLayout>
@@ -124,6 +228,7 @@ export default function ChatPage() {
             onClick={() => {
               setMessages([])
               wsRef.current?.send(JSON.stringify({ type: 'reset' }))
+              closeCitation()
             }}
             sx={{ alignSelf: { xs: 'stretch', md: 'center' } }}
           >
@@ -172,7 +277,21 @@ export default function ChatPage() {
                   ) : (
                     <Box
                       component="div"
-                      sx={{ '& p': { my: 1 }, '& pre': { whiteSpace: 'pre-wrap' } }}
+                      sx={{
+                        '& p': { my: 1 },
+                        '& pre': { whiteSpace: 'pre-wrap' },
+                        '& sup[data-cite-key]': {
+                          cursor: 'pointer',
+                          color: 'primary.main',
+                          fontWeight: 600,
+                          transition: 'color 0.15s ease',
+                        },
+                        '& sup[data-cite-key]:hover': {
+                          color: 'primary.dark',
+                          textDecoration: 'underline',
+                        },
+                      }}
+                      onClick={(event) => handleCitationClick(event, i)}
                       dangerouslySetInnerHTML={{ __html: renderMarkdownToHtml(m.content) }}
                     />
                   )}
@@ -231,6 +350,56 @@ export default function ChatPage() {
             Send
           </Button>
         </Stack>
+
+        <Popover
+          open={Boolean(citationAnchor && activeCitation)}
+          anchorEl={citationAnchor}
+          onClose={closeCitation}
+          anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+          transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+          PaperProps={{
+            sx: {
+              maxWidth: 320,
+              p: 1.5,
+            },
+          }}
+        >
+          {activeCitation ? (
+            <Stack spacing={1}>
+              <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
+                {activeCitation.key}
+              </Typography>
+              {(activeCitation.title || activeCitation.sourceRef) && (
+                <Box>
+                  {activeCitation.title && (
+                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                      {activeCitation.title}
+                    </Typography>
+                  )}
+                  {activeCitation.sourceRef && (
+                    <Typography variant="body2" color="text.secondary">
+                      {activeCitation.sourceRef}
+                    </Typography>
+                  )}
+                </Box>
+              )}
+              {(activeCitation.chunkIndex !== null || activeCitation.similarity !== null) && (
+                <Typography variant="caption" color="text.disabled">
+                  {activeCitation.chunkIndex !== null && `Chunk #${activeCitation.chunkIndex}`}
+                  {activeCitation.chunkIndex !== null && activeCitation.similarity !== null && ' • '}
+                  {activeCitation.similarity != null && `sim ${activeCitation.similarity.toFixed(2)}`}
+                </Typography>
+              )}
+              <Typography variant="body2" sx={{ whiteSpace: 'pre-line' }}>
+                {activeCitation.content}
+              </Typography>
+            </Stack>
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              Citation unavailable
+            </Typography>
+          )}
+        </Popover>
       </Box>
     </ManagementLayout>
   )

--- a/frontend/src/utils/markdown.ts
+++ b/frontend/src/utils/markdown.ts
@@ -31,6 +31,11 @@ function renderInline(md: string): string {
     const label = text
     return `<a href="${href}" target="_blank" rel="noopener noreferrer">${label}</a>`
   })
+  // citations [CITEx]
+  s = s.replace(/\[CITE(\d+)\]/g, (_m, idx) => {
+    const key = `CITE${idx}`
+    return `<sup data-cite-key="${key}">[${key}]</sup>`
+  })
   return s
 }
 


### PR DESCRIPTION
Chunk ingestion now preserves fenced code, splits by sentence/token budgets, and records per-chunk language so new embeddings stay consistent (backend/app/modules/knowledge_base/service.py:381, backend/app/modules/knowledge_base/service.py:544, backend/app/modules/knowledge_base/models.py:36). Existing “update chunk” flow also re-detects language on edits (backend/app/modules/knowledge_base/service.py:568).

Retrieval adds configurable min-sim gating, same-language bias, and MMR diversification with per-document caps, plus uses selectinload to pull document metadata for context (backend/app/modules/knowledge_base/service.py:122, backend/app/modules/knowledge_base/service.py:627). search callers were updated to pass document info during ingest and to unwrap chunks for the public search API (backend/app/api/v1/endpoints/knowledge.py:45, backend/app/api/v1/endpoints/knowledge.py:126).

Added RAG tuning knobs (similarity threshold, oversample, context budget, etc.) and pgvector probe setup so every connection honors the desired ivfflat.probes (backend/app/core/config.py:350, backend/app/infrastructure/database/postgres_base.py:23). Matching environment defaults were documented (.env.example:101, .env.prod.example:101).

Context assembly now enforces token budgets, injects [CITEx] headings with metadata, and falls back to a “no evidence” template when retrieval returns nothing (backend/app/modules/llm/service.py:54, backend/app/modules/llm/service.py:108, backend/app/modules/llm/service.py:165).

Introduced a migration and schema updates for the optional language column so Alembic can evolve the table (backend/alembic/versions/7c2e9e5f3b92_add_language_to_chunks.py:1, backend/app/modules/knowledge_base/schemas.py:32).

Next steps:

Run poetry run alembic upgrade head to add the new column, then backfill existing chunks (e.g., quick script using _detect_language) so the same-language bias can work immediately.

Re-ingest or at least re-embed existing documents if you want code blocks and new chunk sizes applied retroactively.

Smoke-test the WebSocket chat and knowledge search once database fixtures are in place; ensure the UI can surface [CITEx] if you want clickable citations.

Review the new RAG settings in your .env files and adjust thresholds (min similarity, budget, etc.) based on production telemetry.

Tests not run: backend pytest suite requires configured Postgres/vector data; please execute once the env is ready.