### PR TITLE
Refactor admin settings module structure

### DIFF
--- a/backend/app/api/v1/endpoints/admin_settings.py
+++ b/backend/app/api/v1/endpoints/admin_settings.py
@@ -1,46 +1,17 @@
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Any, Dict, Literal
-
-from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, ConfigDict, Field
+from fastapi import APIRouter, Depends
 
 from app.api.dependencies import verify_internal_access
 from app.infrastructure.dynamic_settings import (
     DynamicSettingsService,
     get_dynamic_settings_service,
 )
-
-
-class AdminSettingsResponse(BaseModel):
-    defaults: Dict[str, Any]
-    overrides: Dict[str, Any]
-    effective: Dict[str, Any]
-    updated_at: datetime | None = None
-    redis_status: Literal["ok", "unavailable"] = "ok"
-
-
-class AdminSettingsUpdate(BaseModel):
-    """Allow partial updates while enforcing sensible bounds for each field."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    RAG_TOP_K: int | None = Field(None, ge=1, le=100)
-    RAG_MIN_SIM: float | None = Field(None, ge=0.0, le=1.0)
-    RAG_MMR_LAMBDA: float | None = Field(None, ge=0.0, le=1.0)
-    RAG_PER_DOC_LIMIT: int | None = Field(None, ge=0)
-    RAG_OVERSAMPLE: int | None = Field(None, ge=1)
-    RAG_MAX_CANDIDATES: int | None = Field(None, ge=1)
-    RAG_SAME_LANG_BONUS: float | None = Field(None, ge=0.0, le=5.0)
-    RAG_CONTEXT_TOKEN_BUDGET: int | None = Field(None, ge=0)
-    RAG_CONTEXT_MAX_EVIDENCE: int | None = Field(None, ge=0)
-    RAG_CHUNK_TARGET_TOKENS_EN: int | None = Field(None, ge=1)
-    RAG_CHUNK_TARGET_TOKENS_CJK: int | None = Field(None, ge=1)
-    RAG_CHUNK_TARGET_TOKENS_DEFAULT: int | None = Field(None, ge=1)
-    RAG_CHUNK_OVERLAP_RATIO: float | None = Field(None, ge=0.0, le=1.0)
-    RAG_CODE_CHUNK_MAX_LINES: int | None = Field(None, ge=1)
-    RAG_CODE_CHUNK_OVERLAP_LINES: int | None = Field(None, ge=0)
+from app.modules.admin_settings.schemas import (
+    AdminSettingsResponse,
+    AdminSettingsUpdate,
+)
+from app.modules.admin_settings.service import admin_settings_service
 
 
 router = APIRouter(
@@ -50,53 +21,11 @@ router = APIRouter(
 )
 
 
-def _normalize_overrides(overrides: Dict[str, Any], defaults: Dict[str, Any]) -> Dict[str, Any]:
-    normalized: Dict[str, Any] = {}
-    for key, value in overrides.items():
-        if key in defaults and defaults[key] == value:
-            continue
-        normalized[key] = value
-    return normalized
-
-
-def _parse_updated_at(raw: Any) -> datetime | None:
-    if isinstance(raw, datetime):
-        return raw
-    if isinstance(raw, str):
-        try:
-            return datetime.fromisoformat(raw)
-        except ValueError:
-            return None
-    return None
-
-
 @router.get("/", response_model=AdminSettingsResponse)
 async def read_admin_settings(
     dynamic_settings_service: DynamicSettingsService = Depends(get_dynamic_settings_service),
 ) -> AdminSettingsResponse:
-    defaults = dynamic_settings_service.defaults()
-
-    effective = await dynamic_settings_service.get_all()
-
-    redis_status: Literal["ok", "unavailable"] = "ok"
-    try:
-        overrides = await dynamic_settings_service.get_overrides()
-    except Exception:
-        overrides = {}
-        redis_status = "unavailable"
-
-    metadata = await dynamic_settings_service.get_metadata()
-    updated_at = _parse_updated_at(metadata.get("updated_at")) if metadata else None
-
-    normalized_overrides = _normalize_overrides(overrides, defaults)
-
-    return AdminSettingsResponse(
-        defaults=defaults,
-        overrides=normalized_overrides,
-        effective=effective,
-        updated_at=updated_at,
-        redis_status=redis_status,
-    )
+    return await admin_settings_service.read_settings(dynamic_settings_service)
 
 
 @router.put("/", response_model=AdminSettingsResponse)
@@ -104,30 +33,5 @@ async def update_admin_settings(
     payload: AdminSettingsUpdate,
     dynamic_settings_service: DynamicSettingsService = Depends(get_dynamic_settings_service),
 ) -> AdminSettingsResponse:
-    updates = payload.model_dump(exclude_none=True)
-    if not updates:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No settings provided")
-
-    effective = await dynamic_settings_service.update(updates)
-
-    defaults = dynamic_settings_service.defaults()
-    redis_status: Literal["ok", "unavailable"] = "ok"
-    try:
-        overrides = await dynamic_settings_service.get_overrides()
-    except Exception:
-        overrides = {}
-        redis_status = "unavailable"
-
-    metadata = await dynamic_settings_service.get_metadata()
-    updated_at = _parse_updated_at(metadata.get("updated_at")) if metadata else None
-
-    normalized_overrides = _normalize_overrides(overrides, defaults)
-
-    return AdminSettingsResponse(
-        defaults=defaults,
-        overrides=normalized_overrides,
-        effective=effective,
-        updated_at=updated_at,
-        redis_status=redis_status,
-    )
+    return await admin_settings_service.update_settings(payload, dynamic_settings_service)
 

--- a/backend/app/modules/admin_settings/__init__.py
+++ b/backend/app/modules/admin_settings/__init__.py
@@ -1,0 +1,9 @@
+from .schemas import AdminSettingsResponse, AdminSettingsUpdate
+from .service import AdminSettingsService, admin_settings_service
+
+__all__ = [
+    "AdminSettingsResponse",
+    "AdminSettingsUpdate",
+    "AdminSettingsService",
+    "admin_settings_service",
+]

--- a/backend/app/modules/admin_settings/schemas.py
+++ b/backend/app/modules/admin_settings/schemas.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AdminSettingsResponse(BaseModel):
+    defaults: Dict[str, Any]
+    overrides: Dict[str, Any]
+    effective: Dict[str, Any]
+    updated_at: datetime | None = None
+    redis_status: Literal["ok", "unavailable"] = "ok"
+
+
+class AdminSettingsUpdate(BaseModel):
+    """Allow partial updates while enforcing sensible bounds for each field."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    RAG_TOP_K: int | None = Field(None, ge=1, le=100)
+    RAG_MIN_SIM: float | None = Field(None, ge=0.0, le=1.0)
+    RAG_MMR_LAMBDA: float | None = Field(None, ge=0.0, le=1.0)
+    RAG_PER_DOC_LIMIT: int | None = Field(None, ge=0)
+    RAG_OVERSAMPLE: int | None = Field(None, ge=1)
+    RAG_MAX_CANDIDATES: int | None = Field(None, ge=1)
+    RAG_SAME_LANG_BONUS: float | None = Field(None, ge=0.0, le=5.0)
+    RAG_CONTEXT_TOKEN_BUDGET: int | None = Field(None, ge=0)
+    RAG_CONTEXT_MAX_EVIDENCE: int | None = Field(None, ge=0)
+    RAG_CHUNK_TARGET_TOKENS_EN: int | None = Field(None, ge=1)
+    RAG_CHUNK_TARGET_TOKENS_CJK: int | None = Field(None, ge=1)
+    RAG_CHUNK_TARGET_TOKENS_DEFAULT: int | None = Field(None, ge=1)
+    RAG_CHUNK_OVERLAP_RATIO: float | None = Field(None, ge=0.0, le=1.0)
+    RAG_CODE_CHUNK_MAX_LINES: int | None = Field(None, ge=1)
+    RAG_CODE_CHUNK_OVERLAP_LINES: int | None = Field(None, ge=0)

--- a/backend/app/modules/admin_settings/service.py
+++ b/backend/app/modules/admin_settings/service.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Literal
+
+from fastapi import HTTPException, status
+
+from app.infrastructure.dynamic_settings import DynamicSettingsService
+from .schemas import AdminSettingsResponse, AdminSettingsUpdate
+
+
+class AdminSettingsService:
+    """Business logic for managing dynamic administrator settings."""
+
+    @staticmethod
+    def _normalize_overrides(
+        overrides: Dict[str, Any], defaults: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        normalized: Dict[str, Any] = {}
+        for key, value in overrides.items():
+            if key in defaults and defaults[key] == value:
+                continue
+            normalized[key] = value
+        return normalized
+
+    @staticmethod
+    def _parse_updated_at(raw: Any) -> datetime | None:
+        if isinstance(raw, datetime):
+            return raw
+        if isinstance(raw, str):
+            try:
+                return datetime.fromisoformat(raw)
+            except ValueError:
+                return None
+        return None
+
+    async def read_settings(
+        self, dynamic_settings_service: DynamicSettingsService
+    ) -> AdminSettingsResponse:
+        defaults = dynamic_settings_service.defaults()
+        effective = await dynamic_settings_service.get_all()
+
+        redis_status: Literal["ok", "unavailable"] = "ok"
+        try:
+            overrides = await dynamic_settings_service.get_overrides()
+        except Exception:
+            overrides = {}
+            redis_status = "unavailable"
+
+        metadata = await dynamic_settings_service.get_metadata()
+        updated_at = (
+            self._parse_updated_at(metadata.get("updated_at")) if metadata else None
+        )
+
+        normalized_overrides = self._normalize_overrides(overrides, defaults)
+
+        return AdminSettingsResponse(
+            defaults=defaults,
+            overrides=normalized_overrides,
+            effective=effective,
+            updated_at=updated_at,
+            redis_status=redis_status,
+        )
+
+    async def update_settings(
+        self,
+        payload: AdminSettingsUpdate,
+        dynamic_settings_service: DynamicSettingsService,
+    ) -> AdminSettingsResponse:
+        updates = payload.model_dump(exclude_none=True)
+        if not updates:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="No settings provided",
+            )
+
+        effective = await dynamic_settings_service.update(updates)
+        defaults = dynamic_settings_service.defaults()
+
+        redis_status: Literal["ok", "unavailable"] = "ok"
+        try:
+            overrides = await dynamic_settings_service.get_overrides()
+        except Exception:
+            overrides = {}
+            redis_status = "unavailable"
+
+        metadata = await dynamic_settings_service.get_metadata()
+        updated_at = (
+            self._parse_updated_at(metadata.get("updated_at")) if metadata else None
+        )
+
+        normalized_overrides = self._normalize_overrides(overrides, defaults)
+
+        return AdminSettingsResponse(
+            defaults=defaults,
+            overrides=normalized_overrides,
+            effective=effective,
+            updated_at=updated_at,
+            redis_status=redis_status,
+        )
+
+
+admin_settings_service = AdminSettingsService()


### PR DESCRIPTION
## Summary
- extract the admin settings schemas and service logic into a dedicated module under `app/modules`
- simplify the admin settings API router to delegate processing to the new service layer

## Testing
- PYTHONPATH=. poetry run pytest app/tests/api/test_admin_settings.py

------
https://chatgpt.com/codex/tasks/task_e_68ccc11fc8908324854c804e0eb68913