### PR TITLE
Handle dynamic RAG IVFFLAT probes configuration

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -404,6 +404,7 @@ class Settings(BaseSettings):
             "RAG_CHUNK_OVERLAP_RATIO": self.RAG_CHUNK_OVERLAP_RATIO,
             "RAG_CODE_CHUNK_MAX_LINES": self.RAG_CODE_CHUNK_MAX_LINES,
             "RAG_CODE_CHUNK_OVERLAP_LINES": self.RAG_CODE_CHUNK_OVERLAP_LINES,
+            "RAG_IVFFLAT_PROBES": self.RAG_IVFFLAT_PROBES,
         }
 
 settings = Settings()

--- a/backend/app/infrastructure/database/postgres_base.py
+++ b/backend/app/infrastructure/database/postgres_base.py
@@ -3,6 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sess
 from sqlalchemy import event
 
 from app.core.config import settings
+from app.infrastructure.dynamic_settings import get_dynamic_settings_service
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.ext.declarative import declared_attr
 
@@ -27,12 +28,26 @@ engine = create_async_engine(
     pool_pre_ping=True,
 )
 
+def _resolve_ivfflat_probes() -> int:
+    """Fetch the latest ivfflat probe count from dynamic settings cache."""
+    service = get_dynamic_settings_service()
+    raw_value = service.cached_value("RAG_IVFFLAT_PROBES", settings.RAG_IVFFLAT_PROBES)
+    try:
+        probes = int(raw_value)
+    except (TypeError, ValueError):
+        probes = settings.RAG_IVFFLAT_PROBES
+    if probes <= 0:
+        probes = settings.RAG_IVFFLAT_PROBES
+    return probes
+
+
 # Ensure pgvector uses ivfflat index probes tuned from settings for every connection
 @event.listens_for(engine.sync_engine, "connect", once=False)
 def _configure_pgvector(connection, _):
     try:
         with connection.cursor() as cursor:
-            cursor.execute(f"SET ivfflat.probes = {settings.RAG_IVFFLAT_PROBES}")
+            probes = _resolve_ivfflat_probes()
+            cursor.execute(f"SET ivfflat.probes = {probes}")
     except Exception:
         # Intentionally swallow to avoid breaking app startup if the command fails
         return

--- a/backend/app/infrastructure/dynamic_settings/service.py
+++ b/backend/app/infrastructure/dynamic_settings/service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from datetime import datetime, timezone
 from functools import lru_cache
 from typing import Any, Dict
@@ -29,6 +30,8 @@ class DynamicSettingsService:
         self._settings = settings
         self._redis_key = redis_key or redis_keys.app.dynamic_settings()
         self._meta_key = meta_key or redis_keys.app.dynamic_settings_metadata()
+        self._latest_lock = threading.RLock()
+        self._latest_effective: Dict[str, Any] = self.defaults()
 
     @property
     def redis_key(self) -> str:
@@ -42,6 +45,20 @@ class DynamicSettingsService:
         """Return a fresh copy of default dynamic settings."""
         return dict(self._settings.dynamic_settings_defaults())
 
+    def _set_latest_effective(self, snapshot: Dict[str, Any]) -> None:
+        with self._latest_lock:
+            self._latest_effective = dict(snapshot)
+
+    def cached_effective(self) -> Dict[str, Any]:
+        """Return the most recently observed effective settings snapshot."""
+        with self._latest_lock:
+            return dict(self._latest_effective)
+
+    def cached_value(self, key: str, default: Any | None = None) -> Any:
+        """Return a setting from the cached snapshot, falling back to default."""
+        with self._latest_lock:
+            return self._latest_effective.get(key, default)
+
     async def get_all(self) -> dict[str, Any]:
         """Return merged dynamic settings with Redis overrides when available."""
         defaults = self.defaults()
@@ -52,19 +69,23 @@ class DynamicSettingsService:
             if isinstance(exc, asyncio.CancelledError):
                 raise
             logger.warning("Falling back to default dynamic settings due to Redis error: %s", exc)
+            self._set_latest_effective(defaults)
             return defaults
 
         if not payload:
+            self._set_latest_effective(defaults)
             return defaults
 
         if not isinstance(payload, dict):
             logger.warning(
                 "Dynamic settings payload for key %s is not a JSON object, ignoring", self._redis_key
             )
+            self._set_latest_effective(defaults)
             return defaults
 
         merged: Dict[str, Any] = dict(defaults)
         merged.update(payload)
+        self._set_latest_effective(merged)
         return merged
 
     async def get_overrides(self) -> dict[str, Any]:
@@ -130,6 +151,7 @@ class DynamicSettingsService:
             "updated_at": timestamp,
             "updated_fields": sorted(payload.keys()),
         }
+        self._set_latest_effective(merged)
         try:
             meta_persisted = await self._redis.set_json(self._meta_key, metadata)
             if not meta_persisted:
@@ -140,6 +162,10 @@ class DynamicSettingsService:
             logger.warning("Failed to persist dynamic settings metadata: %s", exc)
 
         return dict(merged)
+
+    async def refresh(self) -> dict[str, Any]:
+        """Refresh the cached snapshot from Redis and return the latest values."""
+        return await self.get_all()
 
 
 @lru_cache(maxsize=1)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -39,7 +39,16 @@ async def lifespan(app: FastAPI):
         await redis_connection_manager.initialize()
         await scheduler_service.initialize()
         logger.info("Redis连接池和调度器初始化成功")
-        
+
+        try:
+            from app.infrastructure.dynamic_settings import get_dynamic_settings_service
+
+            dynamic_settings_service = get_dynamic_settings_service()
+            await dynamic_settings_service.refresh()
+            logger.info("动态配置缓存预热成功")
+        except Exception as exc:
+            logger.warning(f"动态配置缓存预热失败: {exc}")
+
         # 运行启动时维护流程：清理遗留、清理孤儿、确保默认实例
         try:
             legacy = await scheduler_service.cleanup_legacy_artifacts()

--- a/backend/app/modules/admin_settings/schemas.py
+++ b/backend/app/modules/admin_settings/schemas.py
@@ -34,3 +34,4 @@ class AdminSettingsUpdate(BaseModel):
     RAG_CHUNK_OVERLAP_RATIO: float | None = Field(None, ge=0.0, le=1.0)
     RAG_CODE_CHUNK_MAX_LINES: int | None = Field(None, ge=1)
     RAG_CODE_CHUNK_OVERLAP_LINES: int | None = Field(None, ge=0)
+    RAG_IVFFLAT_PROBES: int | None = Field(None, ge=1)

--- a/backend/app/tests/api/test_admin_settings.py
+++ b/backend/app/tests/api/test_admin_settings.py
@@ -46,6 +46,14 @@ class FakeDynamicSettingsService:
     def defaults(self) -> Dict[str, Any]:
         return dict(self._defaults)
 
+    def cached_effective(self) -> Dict[str, Any]:
+        merged = dict(self._defaults)
+        merged.update(self._overrides)
+        return merged
+
+    def cached_value(self, key: str, default: Any | None = None) -> Any:
+        return self.cached_effective().get(key, default)
+
     async def get_all(self) -> Dict[str, Any]:
         merged = dict(self._defaults)
         merged.update(self._overrides)
@@ -109,6 +117,8 @@ def test_admin_settings_get_returns_defaults(admin_client: tuple[TestClient, Fak
     assert data["overrides"] == {}
     assert data["defaults"]["RAG_TOP_K"] == settings.RAG_TOP_K
     assert data["effective"]["RAG_TOP_K"] == settings.RAG_TOP_K
+    assert data["defaults"]["RAG_IVFFLAT_PROBES"] == settings.RAG_IVFFLAT_PROBES
+    assert data["effective"]["RAG_IVFFLAT_PROBES"] == settings.RAG_IVFFLAT_PROBES
     assert data["updated_at"] is None
 
 
@@ -117,7 +127,7 @@ def test_admin_settings_update_overrides_values(admin_client: tuple[TestClient, 
 
     response = client.put(
         "/api/v1/admin/settings",
-        json={"RAG_TOP_K": 7, "RAG_MIN_SIM": 0.55},
+        json={"RAG_TOP_K": 7, "RAG_MIN_SIM": 0.55, "RAG_IVFFLAT_PROBES": 24},
         headers={"X-Internal-Secret": secret},
     )
 
@@ -127,5 +137,7 @@ def test_admin_settings_update_overrides_values(admin_client: tuple[TestClient, 
     assert data["overrides"]["RAG_TOP_K"] == 7
     assert data["effective"]["RAG_TOP_K"] == 7
     assert data["effective"]["RAG_MIN_SIM"] == pytest.approx(0.55)
+    assert data["effective"]["RAG_IVFFLAT_PROBES"] == 24
+    assert data["overrides"]["RAG_IVFFLAT_PROBES"] == 24
     assert data["redis_status"] == "ok"
     assert data["updated_at"] is not None


### PR DESCRIPTION
## Summary
- add RAG_IVFFLAT_PROBES to the dynamic settings defaults and admin settings schema
- cache dynamic settings snapshots and expose cached lookups for the ivfflat probe setting
- update the Postgres ivfflat probe configuration to read the cached setting and warm it during startup

## Testing
- PYTHONPATH=/workspace/React-FastAPI-Postgres/backend pytest app/tests/api/test_admin_settings.py app/tests/infrastructure/test_dynamic_settings_service.py

------
https://chatgpt.com/codex/tasks/task_e_68ccf84ce1d48324b3958e4dd09483b9