### PR TITLE
Fix RAG retrieval configuration and ingestion issues

### DIFF
--- a/backend/app/modules/knowledge_base/ingest_language.py
+++ b/backend/app/modules/knowledge_base/ingest_language.py
@@ -36,7 +36,7 @@ _LINGUA_LOCK = threading.Lock()
 _LINGUA_DETECTOR: T_LanguageDetector | None = None
 logger = logging.getLogger(__name__)
 _LINGUA_AVAILABLE = (_Language is not None and _LanguageDetectorBuilder is not None)
-logger.info("ingest_language: lingua installed=%s", _LINGUA_AVAILABLE)
+logger.debug("ingest_language: lingua installed=%s", _LINGUA_AVAILABLE)
 
 
 def _should_use_lingua(config: Mapping[str, Any] | None) -> bool:
@@ -50,7 +50,7 @@ def _should_use_lingua(config: Mapping[str, Any] | None) -> bool:
         else:
             flag = bool(candidate)
     use = bool(flag and (_LanguageDetectorBuilder is not None))
-    logger.info("ingest_language: should_use_lingua=%s (flag=%s, installed=%s)", use, flag, _LINGUA_AVAILABLE)
+    logger.debug("ingest_language: should_use_lingua=%s (flag=%s, installed=%s)", use, flag, _LINGUA_AVAILABLE)
     return use
 
 
@@ -60,13 +60,13 @@ def _build_lingua_detector() -> T_LanguageDetector | None:
 
     languages = [_Language.ENGLISH, _Language.CHINESE, _Language.JAPANESE]
     try:
-        logger.info("ingest_language: building lingua detector...")
+        logger.debug("ingest_language: building lingua detector...")
         det = (
             _LanguageDetectorBuilder.from_languages(*languages)
             .with_preloaded_language_models()
             .build()
         )
-        logger.info("ingest_language: lingua detector built successfully")
+        logger.debug("ingest_language: lingua detector built successfully")
         return det
     except Exception:  # pragma: no cover - instantiation should rarely fail
         logger.warning("ingest_language: failed to build lingua detector; falling back to heuristics", exc_info=logger.isEnabledFor(logging.DEBUG))
@@ -82,7 +82,7 @@ def _get_lingua_detector() -> T_LanguageDetector | None:
         if _LINGUA_DETECTOR is None:
             _LINGUA_DETECTOR = _build_lingua_detector()
             if _LINGUA_DETECTOR is None:
-                logger.info("ingest_language: lingua detector unavailable")
+                logger.debug("ingest_language: lingua detector unavailable")
     return _LINGUA_DETECTOR
 
 
@@ -130,7 +130,7 @@ def detect_language(
         return default
 
     if is_probable_code(text):
-        logger.info("ingest_language.detect: path=code")
+        logger.debug("ingest_language.detect: path=code")
         return "code"
 
     if _should_use_lingua(config):
@@ -139,19 +139,19 @@ def detect_language(
             try:
                 detected = detector.detect_language_of(text)
                 if _Language and detected == _Language.CHINESE:
-                    logger.info("ingest_language.detect: path=lingua lang=zh")
+                    logger.debug("ingest_language.detect: path=lingua lang=zh")
                     return "zh"
                 if _Language and detected == _Language.JAPANESE:
-                    logger.info("ingest_language.detect: path=lingua lang=ja")
+                    logger.debug("ingest_language.detect: path=lingua lang=ja")
                     return "ja"
                 if _Language and detected == _Language.ENGLISH:
-                    logger.info("ingest_language.detect: path=lingua lang=en")
+                    logger.debug("ingest_language.detect: path=lingua lang=en")
                     return "en"
             except Exception:  # pragma: no cover - lingua failures fall back to heuristics
                 logger.warning("ingest_language.detect: lingua failed; falling back to heuristics",exc_info=logger.isEnabledFor(logging.DEBUG))
 
     lang = _heuristic_language(text) or default
-    logger.info("ingest_language.detect: path=heuristic lang=%s", lang)
+    logger.debug("ingest_language.detect: path=heuristic lang=%s", lang)
     return lang
 
 

--- a/backend/app/modules/knowledge_base/strategy.py
+++ b/backend/app/modules/knowledge_base/strategy.py
@@ -187,16 +187,22 @@ def _apply_scenario(
         overrides["RAG_OVERSAMPLE"] = max(1, min(base_oversample, 3))
         overrides["RAG_MAX_CANDIDATES"] = max(top_k_target * 3, min(base_max_candidates, 80))
         overrides["RAG_RERANK_CANDIDATES"] = max(top_k_target, min(base_rerank_candidates, top_k_target * 3))
-        overrides["RAG_RERANK_SCORE_THRESHOLD"] = max(base_rerank_threshold, 0.6)
+        overrides["RAG_RERANK_SCORE_THRESHOLD"] = min(base_rerank_threshold, 0.55)
         overrides["RAG_CONTEXT_MAX_EVIDENCE"] = max(6, min(base_context_max_evidence, 10))
         overrides["RAG_CONTEXT_TOKEN_BUDGET"] = max(1200, min(base_context_budget, 1800))
     elif scenario == "document_focus":
         overrides["RAG_PER_DOC_LIMIT"] = max(base_per_doc, 6)
-        overrides["RAG_TOP_K"] = max(base_top_k, min(request_top_k, 8))
+        top_k_target = max(base_top_k, min(request_top_k, 8))
+        overrides["RAG_TOP_K"] = top_k_target
         overrides["RAG_MIN_SIM"] = min(0.85, max(base_min_sim, 0.6))
         overrides["RAG_OVERSAMPLE"] = max(base_oversample, 6)
-        overrides["RAG_MAX_CANDIDATES"] = max(base_max_candidates, 160)
-        overrides["RAG_RERANK_CANDIDATES"] = max(base_rerank_candidates, 120)
+        max_candidates_target = max(base_max_candidates, 160)
+        overrides["RAG_MAX_CANDIDATES"] = max_candidates_target
+        rerank_target = max(
+            base_rerank_candidates,
+            min(max_candidates_target, max(top_k_target * 6, 80)),
+        )
+        overrides["RAG_RERANK_CANDIDATES"] = rerank_target
         overrides["RAG_CONTEXT_MAX_EVIDENCE"] = max(base_context_max_evidence, 16)
         overrides["RAG_CONTEXT_TOKEN_BUDGET"] = max(base_context_budget, 2600)
     elif scenario == "question":

--- a/backend/app/modules/knowledge_base/tests/test_service_rerank.py
+++ b/backend/app/modules/knowledge_base/tests/test_service_rerank.py
@@ -96,7 +96,7 @@ def test_rerank_applies_scores(monkeypatch, service):
     dummy_reranker = DummyReranker([2.0, -5.0])
 
     monkeypatch.setattr(service.crud_knowledge_base, "fetch_chunk_candidates_by_embedding", fake_fetch)
-    monkeypatch.setattr(service, "_detect_language", lambda _q: "en")
+    monkeypatch.setattr(service, "_detect_language", lambda _q, _config=None: "en")
     monkeypatch.setattr(service, "_get_reranker", lambda: dummy_reranker)
 
     config_map = {
@@ -143,7 +143,7 @@ def test_rerank_failure_falls_back(monkeypatch, service):
         return [(chunk, 0.1)]
 
     monkeypatch.setattr(service.crud_knowledge_base, "fetch_chunk_candidates_by_embedding", fake_fetch)
-    monkeypatch.setattr(service, "_detect_language", lambda _q: "en")
+    monkeypatch.setattr(service, "_detect_language", lambda _q, _config=None: "en")
 
     failing_reranker = DummyReranker([], raise_on_call=True)
     monkeypatch.setattr(service, "_get_reranker", lambda: failing_reranker)

--- a/backend/app/modules/knowledge_base/tests/test_strategy.py
+++ b/backend/app/modules/knowledge_base/tests/test_strategy.py
@@ -75,7 +75,7 @@ def test_strategy_precise_query_focuses_results():
     assert result.overrides["RAG_OVERSAMPLE"] == 3
     assert result.overrides["RAG_MAX_CANDIDATES"] == 80
     assert result.overrides["RAG_RERANK_CANDIDATES"] == 9
-    assert result.overrides["RAG_RERANK_SCORE_THRESHOLD"] == pytest.approx(0.6)
+    assert "RAG_RERANK_SCORE_THRESHOLD" not in result.overrides
     assert result.overrides["RAG_CONTEXT_MAX_EVIDENCE"] == 10
     assert result.overrides["RAG_CONTEXT_TOKEN_BUDGET"] == 1800
 
@@ -91,7 +91,7 @@ def test_strategy_document_focus_raises_min_similarity():
     assert result.overrides["RAG_MIN_SIM"] == pytest.approx(0.6)
     assert result.overrides["RAG_OVERSAMPLE"] == 6
     assert result.overrides["RAG_MAX_CANDIDATES"] == 160
-    assert result.overrides["RAG_RERANK_CANDIDATES"] == 120
+    assert result.overrides["RAG_RERANK_CANDIDATES"] == 80
     assert result.overrides["RAG_CONTEXT_MAX_EVIDENCE"] == 16
     assert result.overrides["RAG_CONTEXT_TOKEN_BUDGET"] == 2600
 


### PR DESCRIPTION
## Summary
- respect user-provided top_k limits for REST and WebSocket RAG entry points while honoring dynamic caps
- harden rerank pipeline with candidate capping, language-aware scoring, and improved MMR ordering; soften rerank threshold handling
- capture language metadata during ingestion, reduce detection log noise, and reuse cached detections during splitting; tune strategy overrides accordingly

## Testing
- PYTHONPATH=backend pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0fd815c788324b76c65ecf52b6653