### PR TITLE
feat(rag): add query rewriting to retrieval pipeline

### DIFF
--- a/backend/app/api/v1/endpoints/knowledge.py
+++ b/backend/app/api/v1/endpoints/knowledge.py
@@ -182,9 +182,11 @@ async def search_knowledge(
     if max_candidates > 0:
         top_k_value = min(top_k_value, max_candidates)
 
+    effective_query = strategy.processed_query or payload.query
+
     results = await search_similar_chunks(
         db,
-        query=payload.query,
+        query=effective_query,
         top_k=top_k_value,
         dynamic_settings_service=dynamic_settings_service,
         config=strategy_config,

--- a/backend/app/api/v1/endpoints/llm_ws.py
+++ b/backend/app/api/v1/endpoints/llm_ws.py
@@ -113,9 +113,10 @@ async def ws_chat(
             top_k_value = max(1, top_k_value)
 
             try:
+                effective_query = strategy.processed_query or user_text
                 similar = await search_similar_chunks(
                     db,
-                    user_text,
+                    effective_query,
                     top_k_value,
                     dynamic_settings_service=dynamic_settings_service,
                     config=strategy_config,

--- a/backend/app/modules/knowledge_base/tests/test_strategy.py
+++ b/backend/app/modules/knowledge_base/tests/test_strategy.py
@@ -122,6 +122,7 @@ def test_strategy_llm_high_confidence_applies(monkeypatch):
             confidence=0.82,
             reason="diagnosing errors",
             tags=("troubleshooting",),
+            rewritten_query="detailed troubleshooting steps for service failures",
         )
 
     monkeypatch.setattr(intent_classifier, "classify", fake_classify)
@@ -133,6 +134,7 @@ def test_strategy_llm_high_confidence_applies(monkeypatch):
     assert result.classifier is not None
     assert result.classifier.get("applied") is True
     assert result.classifier.get("label") == "troubleshooting"
+    assert result.processed_query == "detailed troubleshooting steps for service failures"
 
 
 def test_strategy_llm_low_confidence_fallback(monkeypatch):
@@ -158,3 +160,4 @@ def test_strategy_llm_low_confidence_fallback(monkeypatch):
     assert result.classifier is not None
     assert result.classifier.get("applied") is False
     assert result.classifier.get("cause") == "low_confidence"
+    assert result.processed_query is None


### PR DESCRIPTION
## Summary
- teach the lightweight intent model to return a retrieval-ready rewritten_query alongside intent metadata
- propagate the rewritten query through the RAG strategy so downstream searches embed the richer text
- cover the new behaviour with strategy tests to assert when rewrites are applied or skipped

## Testing
- PYTHONPATH=backend pytest backend/app/modules/knowledge_base/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d38a1896848324bbd93b488d562941